### PR TITLE
Better Aimbot

### DIFF
--- a/Le_Chiffre/hacks.hpp
+++ b/Le_Chiffre/hacks.hpp
@@ -167,13 +167,29 @@ public:
 	} */
 
 	void aim_bot() {
-		PlayerEntity target = _get_closest_enemy();
+		
+		if (GetAsyncKeyState(VK_LBUTTON))
+		{
+			
+			PlayerEntity target = _get_closest_enemy();
 
-		if (target.valid_player()) {
-			client->set_sensitivity(0.f);
-			player.aim_at(target.get_bone_position(8));
+			if (target.valid_player()) {
+				player.set_attack_state(4);
+				client->set_sensitivity(0.f);
+				player.aim_at(target.get_bone_position(8));
+				Sleep(5);
+				player.set_attack_state(5);
+				Sleep((rand() % 11) + 10); // 10-20 ms
+				player.set_attack_state(4);
+				client->reset_sensitivity();//In fact, the entire aiming and shooting process will be completed within 2 ticks (for a 64tick server), which has almost no effect on the rate of fire
+				
+			}
+			else client->reset_sensitivity();
+			//The side effect is that the thrown object will be thrown immediately, even directly facing the visible enemy.	
+
 		}
 		else client->reset_sensitivity();
+	
 	}
 
 	void bunny_hop() {

--- a/Le_Chiffre/hacks.hpp
+++ b/Le_Chiffre/hacks.hpp
@@ -167,12 +167,11 @@ public:
 	} */
 
 	void aim_bot() {
-		
-		if (GetAsyncKeyState(VK_LBUTTON))
-		{
-			
+		if (GetAsyncKeyState(VK_LBUTTON)) {
 			PlayerEntity target = _get_closest_enemy();
 
+ 			// In fact, the entire aiming and shooting process will be completed within 2 ticks (for a 64tick server), which has almost no effect on the rate of fire
+			// The side effect is that the thrown object will be thrown immediately, even directly facing the visible enemy. 
 			if (target.valid_player()) {
 				player.set_attack_state(4);
 				client->set_sensitivity(0.f);
@@ -181,15 +180,13 @@ public:
 				player.set_attack_state(5);
 				Sleep((rand() % 11) + 10); // 10-20 ms
 				player.set_attack_state(4);
-				client->reset_sensitivity();//In fact, the entire aiming and shooting process will be completed within 2 ticks (for a 64tick server), which has almost no effect on the rate of fire
-				
-			}
-			else client->reset_sensitivity();
-			//The side effect is that the thrown object will be thrown immediately, even directly facing the visible enemy.	
-
+				client->reset_sensitivity();
+			} else {
+				client->reset_sensitivity();
+			}	
+		} else {
+			client->reset_sensitivity();
 		}
-		else client->reset_sensitivity();
-	
 	}
 
 	void bunny_hop() {


### PR DESCRIPTION
Salut,
1#Enhance the realism of aimbot by making the left mouse button pressed before starting to fire
2#Enhance accuracy by firing after aiming starts
    (Will cause a 5ms delay in firing, which is almost impossible to feel)
3#At the same time get the function of automatic continuous shooting
The procedure of firing once will be completed within 2 ticks, and the effect on the rate of fire of the firearm can be ignored.
Known side effects: Throwing objects will be quickly thrown out after pressing the left mouse button
